### PR TITLE
Add index.d.ts to publishable files

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-scripts": "^3.4.1"
   },
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ]
 }


### PR DESCRIPTION
This adds the TypeScript definitions file to the `files` entry of the `package.json` (https://github.com/makannew/use-delayed-state/pull/1#issuecomment-776636156).

Confirmed with `npm pub --dry`:

<img width="226" alt="Screen Shot 2021-02-10 at 11 20 12" src="https://user-images.githubusercontent.com/6205451/107503534-fa60a600-6b91-11eb-8c9e-37c4cefdc13d.png">
